### PR TITLE
TOS: Corrected type for accurate definition of 'Disney'

### DIFF
--- a/tos.md
+++ b/tos.md
@@ -6,7 +6,7 @@ These Terms of Service govern your use of our services, as outlined below. When 
 * "we", "us", and "our" refer to the company "Corporate Clash".
 * "you" and "your" refer to your account, you, or anyone with access to your account. 
 * "Corporate Clash entities" refers to the officers, directors, employees, and volunteers that help us run our services.
-* “Disney” may referrer to The Walt Disney Company or any of its subsidiaries. 
+* “Disney” may refer to The Walt Disney Company or any of its subsidiaries.
 
 We are not affiliated with Disney.
 


### PR DESCRIPTION
"Referrer" would be incorrect here because it typically refers to someone, an **entity**, or something that refers or directs someone to something else, which doesn't fit the intended meaning in this context, as 'Disney' is an alias that refers to the Walt Disney Company, and any of its subsidiaries.